### PR TITLE
Fix some bugs in the KNN assignment notebook

### DIFF
--- a/Programming assignment, week 4: KNN features/compute_KNN_features.ipynb
+++ b/Programming assignment, week 4: KNN features/compute_KNN_features.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Version 1.1.0"
+    "Version 1.1.1"
    ]
   },
   {
@@ -44,7 +44,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -87,7 +89,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "train_path = '../readonly/KNN_features_data/X.npz'\n",
@@ -120,7 +124,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from sklearn.base import BaseEstimator, ClassifierMixin\n",
@@ -197,6 +203,7 @@
     "            # test_feats =  # YOUR CODE GOES HERE\n",
     "            # YOUR CODE GOES HERE\n",
     "            \n",
+    "            # Comment out this line once you implement the code\n",
     "            assert False, 'You need to implement it for n_jobs > 1'\n",
     "            \n",
     "            \n",
@@ -354,7 +361,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# a list of K in KNN, starts with one \n",
@@ -373,9 +382,9 @@
     "test_knn_feats = NNF.predict(X_test[:50])\n",
     "\n",
     "# This should be zero\n",
-    "print ('Deviation from ground thruth features: %f' % np.abs(test_knn_feats - true_knn_feats_first50[44:45]).sum())\n",
+    "print ('Deviation from ground thruth features: %f' % np.abs(test_knn_feats - true_knn_feats_first50).sum())\n",
     "\n",
-    "deviation =np.abs(test_knn_feats - true_knn_feats_first50[44:45]).sum(0)\n",
+    "deviation =np.abs(test_knn_feats - true_knn_feats_first50).sum(0)\n",
     "for m in np.where(deviation > 1e-3)[0]: \n",
     "    p = np.where(np.array([87, 88, 117, 146, 152, 239]) > m)[0][0]\n",
     "    print ('There is a problem in feature %d, which is a part of section %d.' % (m, p + 1))"
@@ -405,7 +414,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "for metric in ['minkowski', 'cosine']:\n",
@@ -441,7 +452,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Differently from other homework we will not implement OOF predictions ourselves\n",
@@ -485,7 +498,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "s = 0\n",
@@ -509,10 +524,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from grader import Grader\n",
+    "\n",
+    "grader = Grader()\n",
     "\n",
     "grader.submit_tag('statistic', answer)\n",
     "\n",


### PR DESCRIPTION
Let's fix some remaining bugs in the KNN assignment notebook.

1. In the sanity check cell, it compared `test_knn_feats` (shape: (50, 239)) and `true_knn_feats_first50[44:45]` (shape: (1, 239)). So just remove `[44:45]`.
2. In the submit cell, it lost the initialization of the Grader. So add it.
3. In addition, add a comment to remind people of commenting out the assertion in method `NearestNeighborsFeats.predict`.